### PR TITLE
removed CopperheadOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1868,18 +1868,6 @@ Mit Mail-in-a-Box kannst du in ein paar einfachen Schritten dein eigener Mail-Di
 </div>
 </div>
 </div>
-<div class="col-sm-4">
-<div class="panel panel-warning">
-<div class="panel-heading">
-<h3 class="panel-title">CopperheadOS</h3>
-</div>
-<div class="panel-body">
-<p><img src="img/tools/CopperheadOS.png" alt="CopperheadOS" align="right" style="margin-left:5px;">CopperheadOS ist ein geh&auml;rtetes, mobiles Betriebssystem von Copperhead Security. Es ist quelloffen und basiert auf Android. Es wird ein hoher Wert auf Sicherheit und Privatsph&auml;re gelegt.  Der Kernel wurde geh&auml;rtet und Sandbox-Dienste zur Isolation der Apps wurden implementiert. Aktuell ist es f&uuml;r Pixel und Nexus Smartphones verf&uuml;gbar.</p>
-<p><a href="https://copperhead.co/android/" target="_blank"><button type="button" class="btn btn-warning">Webseite: copperhead.co</button></a></p>
-</div>
-</div>
-</div>
-
 </div>
 
 <h3>Erw&auml;hnenswert:</h3>


### PR DESCRIPTION
CopperheadOS aus dem "Mobilen Betirebssystem" Sektor entfernt, da die Sicherheit nicht mehr gewährleistet scheint:
Quelle: https://www.reddit.com/r/CopperheadOS/comments/8qdnn3/goodbye/

Nach einer Alternative wird gesucht.